### PR TITLE
updated dockerfile

### DIFF
--- a/Spark-master/Dockerfile
+++ b/Spark-master/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     openjdk-17-jdk\
     rclone\
-    && pip install delta-spark==$DELTA_VERSION papermill openpyxl yfinance msal \
+    && pip install delta-spark==$DELTA_VERSION papermill openpyxl yfinance msal psycopg2-binary \
     && curl -o /tmp/hadoop.tar.gz "https://downloads.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz"\
     && tar -xzf /tmp/hadoop.tar.gz -C /usr/local/ && \
     mv /usr/local/hadoop-${HADOOP_VERSION} ${HADOOP_HOME} && \

--- a/Spark-master/Dockerfile
+++ b/Spark-master/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /mnt /data /home/jovyan/Notebooks /home/jovyan/Notebooks/output /mn
     chown -R jovyan:users /mnt/onedrive ${SPARK_HOME} ${HADOOP_HOME} /home/jovyan/.jupyter /home/jovyan/Notebooks /home/jovyan/Notebooks/output
 
 # Expose necessary ports for Jupyter Notebook, Spark, and rclone remote control (5572)
-EXPOSE 8888 8082 7077 5572
+EXPOSE 8888 8082 7077
 
 # Switch back to the default user
 USER jovyan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,62 @@
-version: '3.9'
+
+networks:
+  SPARK_CLUSTER:
+    driver: bridge
+    name: SPARK_CLUSTER
 
 services:
   spark-master:
-    image: anoopm2801/spark-worker:latest
+    build:
+      context: .
+      dockerfile: ./spark-master/Dockerfile
     container_name: spark-master
-    environment:
-      SPARK_MASTER_HOST: spark-master
-      SPARK_MASTER_URL: spark://spark-master:7077
+    image: spark-cluster:version-1.0.0
+    networks:
+      - SPARK_CLUSTER
     ports:
-      - "8080:8080"
-      - "7077:7077"
-      - "8888:8888"
-  
+      - "8888:8888"  # Jupyter Notebook
+      - "7077:7077"  # Spark Master RPC Port
+      - "8082:8080"  # Master Web UI
+      # - "5572:5572" # rclone RC Port
+    environment:
+      - SPARK_MASTER_HOST=spark-master
+      - SPARK_MASTER_URL=spark://spark-master:7077
+    volumes:
+      - /Users/anoopm/my_jupyter_project/Docker_setup/fat.jar:/app/setup/fat.jar
+      - /Users/anoopm/my_jupyter_project/Scripts:/home/jovyan/Notebooks
+      - /Users/anoopm/Documents/Local_Folder:/mnt
+      - /Users/anoopm/Library/CloudStorage/OneDrive-Personal/Cloud_Documents:/data
+      - /Users/anoopm/Documents/Spark_Work:/usr/local/spark/work
+      - /Users/anoopm/my_jupyter_project/Docker_setup/spark-master:/usr/local/spark/conf
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      interval: 30s
+      retries: 3
+      start_period: 10s
+      timeout: 10s
+
   spark-worker:
-    image: anoopm2801/spark-master:latest
-    container_name: spark-worker
-    environment:
-      SPARK_MASTER: spark://spark-master:7077
-      SPARK_WORKER_CORES: "2"
-      SPARK_WORKER_MEMORY: "1G"
+    build:
+      context: .
+      dockerfile: ./spark-worker/Dockerfile
+    image: spark-worker:version1.0.0
+    networks:
+      - SPARK_CLUSTER
     depends_on:
-      - spark-master
+      spark-master:
+        condition: service_healthy
+    environment:
+      - SPARK_MASTER=spark://spark-master:7077
+      - SPARK_WORKER_CORES=2
+      - SPARK_WORKER_MEMORY=1G
+    volumes:
+      - /Users/anoopm/my_jupyter_project/Docker_setup/fat.jar:/app/setup/fat.jar
+      - /Users/anoopm/my_jupyter_project/Scripts:/home/jovyan/Notebooks
+      - /Users/anoopm/Documents/Local_Folder:/mnt
+      - /Users/anoopm/Library/CloudStorage/OneDrive-Personal/Cloud_Documents:/data
+      - /Users/anoopm/Documents/Spark_Work:/usr/local/spark/work
+      - /Users/anoopm/my_jupyter_project/Docker_setup/spark-master/spark-defaults.json:${SPARK_HOME}/conf/spark-defaults.json
+      - /Users/anoopm/my_jupyter_project/Docker_setup/spark-master/packages.txt:/usr/local/spark/conf/packages.txt
     ports:
-      - "8081:8081"
-      - "7337:7337"
+      - "8081:8081"  # Worker Web UI
+      - "7337:7337"  # Worker Communication Port


### PR DESCRIPTION
## Summary by Sourcery

Update the Docker configuration to build Spark master and worker images from local Dockerfiles. Install the `psycopg2-binary` package. Configure a health check for the Spark master service and set up networking between master and worker. Mount necessary volumes and set environment variables for Spark configuration.

Build:
- Update the Dockerfile to install the `psycopg2-binary` package.
- Configure the spark-master service with a health check to ensure that the service is running before starting the spark-worker service.
- Update the docker-compose file to build images from local Dockerfiles and tag them with versions.
- Add a network for the Spark cluster and connect both master and worker to it.
- Mount project files and dependencies as volumes in both spark-master and spark-worker containers.
- Set environment variables for Spark configuration in both master and worker containers.
- Expose ports for Jupyter Notebook, Spark Master RPC, and Master Web UI.
- Update the Dockerfile to remove the rclone port exposure and update pip packages