### PR TITLE
updated

### DIFF
--- a/Spark-master/jupyter_notebook_config.py
+++ b/Spark-master/jupyter_notebook_config.py
@@ -1,0 +1,5 @@
+c = get_config()
+c.NotebookApp.ip = '0.0.0.0'
+c.NotebookApp.open_browser = False
+c.NotebookApp.port = 8888
+


### PR DESCRIPTION
## Summary by Sourcery

Configure Jupyter Notebook to listen on all IPs, disable browser opening, and use port 8888.